### PR TITLE
When extracting file, return it's full filepath

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ hxdmp = "0.2.1"
 simple_logger = "2.3.0"
 xz2 = "0.1.7"
 clap = { version = "4.0.12", features = ["derive"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/lfs/test_04/out.squashfs
+++ b/lfs/test_04/out.squashfs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfb3424bf3b744b8c7a156c9c538310c49fbe8a57f336864f00210e6f356f2c3
+size 4096

--- a/lfs/test_04/testing/03
+++ b/lfs/test_04/testing/03
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90117dea9028cf65911c2024f11aa3fcc555b847cb5e44e93e7bd890d79cfb88
+size 23

--- a/lfs/test_04/testing/what/04
+++ b/lfs/test_04/testing/what/04
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:784636e0b138cf6182fc9af9b39ff9c38ae3ffd0b6b78381a55ba595ffc78a1c
+size 35

--- a/lfs/test_04/testing/what/yikes/01
+++ b/lfs/test_04/testing/what/yikes/01
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c1527ba3e29054d348279f66592bc7d7ad4441bf18e5478906f918793d3562c
+size 44

--- a/lfs/test_04/testing/what/yikes/02
+++ b/lfs/test_04/testing/what/yikes/02
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4818e2fdfafe27b1b42ee15fdd6494194e534ecc5667acddfbaa3ac9311df31
+size 34

--- a/lfs/test_04/testing/woah/05
+++ b/lfs/test_04/testing/woah/05
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a2c0fe812a83a3a906c1f3c0ee55f9fad520610d361b6afd5c3dedeaa287a39
+size 34

--- a/lfs/test_05/a/b/c/d
+++ b/lfs/test_05/a/b/c/d
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0641203cb2bbb7d75bcc537f38627caa301f3df01a2cea539b34274d6bbef7f1
+size 39

--- a/lfs/test_05/out.squashfs
+++ b/lfs/test_05/out.squashfs
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6195e4d8d14c63dffa9691d36efa1eda2ee975b476bb95d4a0b59638fd9973cb
+size 4096

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 use std::io::{Read, Seek, SeekFrom};
+use std::path::PathBuf;
 
 use deku::prelude::*;
+use tracing::instrument;
 use xz2::read::XzDecoder;
 
 const FRAGMENT_SIZE: usize =
@@ -136,10 +138,12 @@ pub struct Metadata {
 }
 
 impl Metadata {
+    /// Check is_compressed bit within raw `len`
     pub fn is_compressed(len: u16) -> bool {
         len & METADATA_COMPRESSED == 0
     }
 
+    /// Get actual length of `data` following `len` from unedited `len`
     pub fn len(len: u16) -> u16 {
         len & !(METADATA_COMPRESSED)
     }
@@ -156,6 +160,7 @@ pub struct Squashfs {
 
 /// public
 impl Squashfs {
+    #[instrument(skip_all)]
     pub fn from_reader<R: ReadSeek + 'static>(mut reader: R) -> Self {
         // Size of metadata + optional compression options metadata block
         let mut superblock = [0u8; 96 + 8];
@@ -187,24 +192,55 @@ impl Squashfs {
         }
     }
 
-    /// Parse Directory Table
-    pub fn dirs(&mut self) -> Vec<Dir> {
-        let offset = self.superblock.dir_table;
-        let seek = SeekFrom::Start(offset);
-        let size = self.superblock.frag_table - offset;
-
-        self.metadatas::<Dir>(seek, size)
-    }
-
-    /// Parse Inode Table
-    pub fn inodes(&mut self) -> Vec<Inode> {
+    /// Parse Inodes
+    #[instrument(skip_all)]
+    pub fn inodes(&mut self) -> Vec<(usize, Inode)> {
         self.metadatas::<Inode>(
             SeekFrom::Start(self.superblock.inode_table),
             self.superblock.dir_table - self.superblock.inode_table,
         )
     }
 
+    /// Extract the root `Inode` as a `BasicDirectory`
+    #[instrument(skip_all)]
+    pub fn root_inode(&mut self, inodes: &Vec<(usize, Inode)>) -> BasicDirectory {
+        let (_, root_inode) = inodes
+            .iter()
+            .find(|(pos, inode)| *pos == self.superblock.root_inode as usize)
+            .unwrap();
+        let root_inode = root_inode.expect_dir();
+        root_inode.clone()
+    }
+
+    /// From `Vec<usize, Inode>`, give `Vec<Inode>
+    #[instrument(skip_all)]
+    pub fn discard_pos(&mut self, inodes: &Vec<(usize, Inode)>) -> Vec<Inode> {
+        inodes
+            .clone()
+            .into_iter()
+            .map(|(_pos, inode)| inode)
+            .collect()
+    }
+
+    /// Parse required number of `Metadata`s uncompressed blocks required for `Dir`s
+    #[instrument(skip_all)]
+    pub fn dir_blocks(&mut self, inodes: &Vec<Inode>) -> Vec<Vec<u8>> {
+        let mut max_metadata = 0;
+        for inode in inodes {
+            if let Inode::BasicDirectory(basic_dir) = inode {
+                if basic_dir.block_index > max_metadata {
+                    max_metadata = basic_dir.block_index;
+                }
+            }
+        }
+
+        let offset = self.superblock.dir_table;
+        let seek = SeekFrom::Start(offset);
+        self.metadata_blocks(seek, u64::from(max_metadata) + 1, true)
+    }
+
     /// Parse Fragment Table
+    #[instrument(skip_all)]
     pub fn fragments(&mut self) -> Option<Vec<Fragment>> {
         if self.superblock.frag_count == 0 {
             return None;
@@ -217,58 +253,137 @@ impl Squashfs {
         Some(fragment)
     }
 
-    /// Extract file from squashfs filesystem
-    ///
-    /// Extract file from a already parsed Directory Table and Inode table from a squashfs
-    /// filesystem. This doesn't respect filepaths, and instead just gives you the bytes
-    /// representing that file.
-    // TODO: for now, this requires you to have ALL the Inodes already deserialized, but the
-    // Dir/BasicFile gives information as to where the inode is located, so use that in the future
-    // instead of passing in `inodes`
+    /// Give a file_name from a squashfs filepath, extract the file and the filepath
+    #[instrument(skip_all)]
     pub fn extract_file(
         &mut self,
         name: &str,
-        dirs: &[Dir],
+        dir_blocks: &Vec<Vec<u8>>,
         inodes: &[Inode],
         fragments: &Option<Vec<Fragment>>,
-    ) -> Vec<u8> {
-        // search through dirs for file name that matches
+        root_inode: &BasicDirectory,
+    ) -> (PathBuf, Vec<u8>) {
         let mut found_directory = None;
-        for dir in dirs {
-            for entry in &dir.dir_entries {
-                if name == std::str::from_utf8(&entry.name).unwrap() {
-                    found_directory = Some((dir.inode_num, entry));
+        // Search through inodes and parse directory table at the specified location
+        // searching for first file name that matches
+        'outer: for inode in inodes {
+            tracing::trace!("Searching following inode for filename: {inode:#02x?}");
+            if let Inode::BasicDirectory(basic_dir) = inode {
+                let block = &dir_blocks[basic_dir.block_index as usize];
+                let bytes = &block[basic_dir.block_offset as usize..];
+                let (_, dir) = Dir::from_bytes((bytes, 0)).unwrap();
+                tracing::trace!("Searching following dir for filename: {dir:#02x?}");
+                for entry in dir.dir_entries {
+                    let entry_name = std::str::from_utf8(&entry.name).unwrap();
+                    tracing::debug!(entry_name);
+                    if name == entry_name {
+                        found_directory = Some((inode, dir.inode_num, entry));
+                        break 'outer;
+                    }
+                }
+            }
+        }
+        tracing::debug!("found matching inode/dir: {found_directory:#02x?}");
+
+        // We now have the:
+        // (
+        //     directory inode matching the filename,
+        //     base_inode(directory base inode_num)
+        //     entry from dir.entires that matches the filename
+        //  )
+        let (dir_inode, base_inode, entry) = found_directory.unwrap();
+        let dir_inode = dir_inode.expect_dir();
+        // Used for searching for the file later when we want to extract the bytes
+        let looking_inode = base_inode as i16 + entry.inode_offset;
+
+        let root_inode = root_inode.header.inode_number;
+        tracing::debug!("searching for dir path to root inode: {:#02x?}", root_inode);
+
+        let mut path_inodes = vec![];
+        // first check if the dir inode of this file is the root inode
+        if dir_inode.header.inode_number != root_inode {
+            // check every inode and find the matching inode to the current dir_nodes parent
+            // inode, when we find a new inode, check if it's the root inode, and continue on if it
+            // isn't
+            let mut next_inode = dir_inode.parent_inode;
+            'outer: loop {
+                for inode in inodes {
+                    if let Inode::BasicDirectory(basic_dir) = inode {
+                        if basic_dir.header.inode_number == next_inode {
+                            path_inodes.push(basic_dir);
+                            if basic_dir.header.inode_number == root_inode {
+                                break 'outer;
+                            }
+                            next_inode = basic_dir.parent_inode;
+                        }
+                    }
                 }
             }
         }
 
-        // TODO: exit nicely in the future
-        let (base_inode, entry) = found_directory.unwrap();
-        let looking_inode = base_inode as i16 + entry.inode_offset;
+        // Insert the first basic file
+        path_inodes.insert(0, dir_inode);
 
-        // look through basic file inodes in search of the one true basic_inode
+        let mut paths = vec![];
+        // Now we use n as the basic_dir with the inode, and look for that inode in the next
+        // dir at the path directed from the path_inodes, when it matches, save it to the paths
+        for n in 0..path_inodes.len() - 1 {
+            let basic_dir_with_inode = path_inodes[n];
+            let search_inode = basic_dir_with_inode.header.inode_number;
+
+            let basic_dir_with_location = path_inodes[n + 1];
+            let block = &dir_blocks[basic_dir_with_location.block_index as usize];
+            let bytes = &block[basic_dir_with_location.block_offset as usize..];
+
+            let (_, dir) = Dir::from_bytes((bytes, 0)).unwrap();
+            let base_inode = dir.inode_num;
+
+            for entry in &dir.dir_entries {
+                let entry_name = std::str::from_utf8(&entry.name).unwrap();
+                if base_inode as i16 + entry.inode_offset == search_inode as i16 {
+                    let entry_name = String::from_utf8(entry.name.clone()).unwrap();
+                    paths.push(entry_name);
+                }
+            }
+        }
+
+        // reverse the order, since we are looking at the file to the parent dirs
+        let paths: Vec<&String> = paths.iter().rev().collect();
+
+        // create PathBufs
+        let mut pathbuf = PathBuf::new();
+        for path in paths {
+            pathbuf.push(path);
+        }
+        pathbuf.push(name);
+        tracing::debug!("path: {}", pathbuf.display());
+
+        // look through basic file inodes in search of the one true basic_inode and extract the
+        // bytes from the data and fragment sections
         for inode in inodes {
             if let Inode::BasicFile(basic_file) = inode {
                 if basic_file.header.inode_number == looking_inode as u32 {
-                    return self.data(basic_file, fragments);
+                    return (pathbuf, self.data(basic_file, fragments));
                 }
             }
         }
-        todo!();
+        todo!("file not found, did you give me a dir name?");
     }
 }
 
 /// private
 impl Squashfs {
     /// Parse Lookup Table
+    #[instrument(skip_all)]
     fn lookup_table<T: for<'a> DekuContainerRead<'a>>(
         &mut self,
         seek: SeekFrom,
         size: u64,
     ) -> Vec<T> {
-        println!(
+        tracing::debug!(
             "Lookup Table: seek {:02x?}, metadata size: {:02x?}",
-            seek, size
+            seek,
+            size
         );
         // find the pointer at the initial offset
         self.io.seek(seek).unwrap();
@@ -282,30 +397,36 @@ impl Squashfs {
     }
 
     /// Parse multiple `Metadata` block at offset into `T`
-    fn metadatas<T: for<'a> DekuContainerRead<'a>>(&mut self, seek: SeekFrom, size: u64) -> Vec<T> {
-        println!("Metadata: seek {:02x?}, size: {:02x?}", seek, size);
+    #[instrument(skip_all)]
+    fn metadatas<T: for<'a> DekuContainerRead<'a>>(
+        &mut self,
+        seek: SeekFrom,
+        size: u64,
+    ) -> Vec<(usize, T)> {
+        tracing::debug!("Metadata: seek {:02x?}, size: {:02x?}", seek, size);
         self.io.seek(seek).unwrap();
+
+        // The directory inodes store the total, uncompressed size of the entire listing, including headers.
+        // Using this size, a SquashFS reader can determine if another header with further entries
+        // should be following once it reaches the end of a run.
 
         // TODO: with capacity?
         let mut ret_bytes = vec![];
         let mut all_read = 0;
 
-        pub const METADATA_SIZE: usize = 8 * 1024;
         while all_read <= size {
             // parse into metadata
-            println!("{:02x?}", size);
-            let mut buf = vec![0u8; size as usize];
+            let mut buf = vec![0u8; (size - all_read) as usize];
             self.io.read_exact(&mut buf).unwrap();
-            all_read += METADATA_SIZE as u64;
             if let Ok((_, m)) = Metadata::from_bytes((&buf, 0)) {
-                //println!("Metadata: {m:?}");
-
                 // decompress
                 let mut bytes = if Metadata::is_compressed(m.len) {
                     self.decompress(m.data)
                 } else {
                     m.data
                 };
+
+                all_read += bytes.len() as u64;
                 ret_bytes.append(&mut bytes);
             } else {
                 break;
@@ -315,11 +436,14 @@ impl Squashfs {
 
         // TODO: with capacity?
         let mut ret_vec = vec![];
+        let mut total_read = 0;
         // TODO: this can be calculate better w.r.t the length of these bytes and the failure.
         loop {
             match T::from_bytes((&ret_bytes, 0)) {
                 Ok(((rest, _), t)) => {
-                    ret_vec.push(t);
+                    // Push the new T to the return, with the position this was read from
+                    ret_vec.push((total_read, t));
+                    total_read += ret_bytes.len() - rest.len();
                     ret_bytes = rest.to_vec();
                 },
                 Err(_) => {
@@ -332,15 +456,17 @@ impl Squashfs {
     }
 
     /// Parse count of `Metadata` block at offset into `T`
+    #[instrument(skip_all)]
     fn metadata_with_count<T: for<'a> DekuContainerRead<'a>>(
         &mut self,
         seek: SeekFrom,
         count: u64,
         can_be_compressed: bool,
     ) -> Vec<T> {
-        println!(
+        tracing::debug!(
             "Metadata with count: seek {:02x?}, count: {:02x?}",
-            seek, count
+            seek,
+            count
         );
         self.io.seek(seek).unwrap();
 
@@ -349,12 +475,13 @@ impl Squashfs {
         for _ in 0..count {
             let mut buf = [0u8; 2];
             self.io.read_exact(&mut buf).unwrap();
+            let metadata_len = u16::from_le_bytes(buf);
 
-            let len = Metadata::len(u16::from_le_bytes(buf));
-            let mut buf = vec![0u8; len as usize];
+            let byte_len = Metadata::len(metadata_len);
+            let mut buf = vec![0u8; byte_len as usize];
             self.io.read_exact(&mut buf).unwrap();
 
-            let mut bytes = if can_be_compressed && Metadata::is_compressed(len) {
+            let mut bytes = if can_be_compressed && Metadata::is_compressed(metadata_len) {
                 self.decompress(buf)
             } else {
                 buf
@@ -380,9 +507,43 @@ impl Squashfs {
         ret_vec
     }
 
+    /// Parse into Metadata uncompressed blocks
+    #[instrument(skip_all)]
+    fn metadata_blocks(
+        &mut self,
+        seek: SeekFrom,
+        count: u64,
+        can_be_compressed: bool,
+    ) -> Vec<Vec<u8>> {
+        tracing::debug!("Seeking to 0x{seek:02x?}");
+        self.io.seek(seek).unwrap();
+
+        let mut all_bytes = vec![];
+        // in order to grab a `count` of Metadatas, we can't use Deku for usage of std::io::Read
+        for _ in 0..count {
+            let mut buf = [0u8; 2];
+            self.io.read_exact(&mut buf).unwrap();
+            let metadata_len = u16::from_le_bytes(buf);
+
+            let byte_len = Metadata::len(metadata_len);
+            let mut buf = vec![0u8; byte_len as usize];
+            self.io.read_exact(&mut buf).unwrap();
+
+            let bytes = if can_be_compressed && Metadata::is_compressed(metadata_len) {
+                self.decompress(buf)
+            } else {
+                buf
+            };
+            all_bytes.push(bytes);
+        }
+
+        all_bytes
+    }
+
+    #[instrument(skip_all)]
     fn data(&mut self, basic_file: &BasicFile, fragments: &Option<Vec<Fragment>>) -> Vec<u8> {
+        tracing::debug!("extracting: {basic_file:#02x?}");
         let start_of_data = basic_file.blocks_start as u64;
-        //println!("Data: seek_start: {start_of_data:02x?}");
 
         // seek to start of data
         self.io.seek(SeekFrom::Start(start_of_data)).unwrap();
@@ -426,10 +587,15 @@ impl Squashfs {
             }
         }
 
+        data_bytes = data_bytes[basic_file.block_offset as usize..]
+            [..basic_file.file_size as usize]
+            .to_vec();
+
         data_bytes
     }
 
     /// Using the current compressor from the superblock, decompress bytes
+    #[instrument(skip_all)]
     fn decompress(&self, bytes: Vec<u8>) -> Vec<u8> {
         let mut out = vec![];
         match self.superblock.compressor {
@@ -477,7 +643,7 @@ pub struct SuperBlock {
     pub export_table: u64,
 }
 
-#[derive(Debug, DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite, Clone)]
 #[deku(type = "u16")]
 #[deku(endian = "little")]
 pub enum Inode {
@@ -488,7 +654,17 @@ pub enum Inode {
     BasicFile(BasicFile),
 }
 
-#[derive(Debug, DekuRead, DekuWrite)]
+impl Inode {
+    pub fn expect_dir(&self) -> &BasicDirectory {
+        if let Self::BasicDirectory(basic_dir) = self {
+            basic_dir
+        } else {
+            panic!("not a dir");
+        }
+    }
+}
+
+#[derive(Debug, DekuRead, DekuWrite, Clone)]
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
 pub struct InodeHeader {
     permissions: u16,
@@ -498,7 +674,7 @@ pub struct InodeHeader {
     inode_number: u32,
 }
 
-#[derive(Debug, DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite, Clone)]
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
 pub struct BasicDirectory {
     header: InodeHeader,
@@ -509,7 +685,7 @@ pub struct BasicDirectory {
     parent_inode: u32,
 }
 
-#[derive(Debug, DekuRead, DekuWrite)]
+#[derive(Debug, DekuRead, DekuWrite, Clone)]
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
 pub struct BasicFile {
     pub header: InodeHeader,
@@ -548,6 +724,7 @@ pub struct Dir {
     pub dir_entries: Vec<DirEntry>,
 }
 
+// TODO: derive our own Debug, with name()
 #[derive(Debug, DekuRead, DekuWrite)]
 #[deku(endian = "endian", ctx = "endian: deku::ctx::Endian")]
 pub struct DirEntry {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -8,12 +8,21 @@ fn test_00() {
     let file = File::open("./lfs/test_00/out.squashfs").unwrap();
     let mut squashfs = Squashfs::from_reader(file);
 
-    let dirs = squashfs.dirs();
-    let inodes = squashfs.inodes();
+    let pos_and_inodes = squashfs.inodes();
+    let root_inode = squashfs.root_inode(&pos_and_inodes);
+    let inodes = squashfs.discard_pos(&pos_and_inodes);
+    let dir_blocks = squashfs.dir_blocks(&inodes);
     let fragments = squashfs.fragments();
 
-    let bytes = squashfs.extract_file("squashfs-deku", &dirs, &inodes, &fragments);
+    let (path, bytes) = squashfs.extract_file(
+        "squashfs-deku",
+        &dir_blocks,
+        &inodes,
+        &fragments,
+        &root_inode,
+    );
     let expected_bytes = fs::read("./lfs/test_00/squashfs-deku").unwrap();
+    assert_eq!(path.as_os_str(), "squashfs-deku");
     assert_eq!(bytes, expected_bytes);
 }
 
@@ -23,12 +32,21 @@ fn test_01() {
     let file = File::open("./lfs/test_01/out.squashfs").unwrap();
     let mut squashfs = Squashfs::from_reader(file);
 
-    let dirs = squashfs.dirs();
-    let inodes = squashfs.inodes();
+    let pos_and_inodes = squashfs.inodes();
+    let root_inode = squashfs.root_inode(&pos_and_inodes);
+    let inodes = squashfs.discard_pos(&pos_and_inodes);
+    let dir_blocks = squashfs.dir_blocks(&inodes);
     let fragments = squashfs.fragments();
 
-    let bytes = squashfs.extract_file("squashfs-deku", &dirs, &inodes, &fragments);
+    let (path, bytes) = squashfs.extract_file(
+        "squashfs-deku",
+        &dir_blocks,
+        &inodes,
+        &fragments,
+        &root_inode,
+    );
     let expected_bytes = fs::read("./lfs/test_01/squashfs-deku").unwrap();
+    assert_eq!(path.as_os_str(), "squashfs-deku");
     assert_eq!(bytes, expected_bytes);
 }
 
@@ -38,12 +56,21 @@ fn test_02() {
     let file = File::open("./lfs/test_02/out.squashfs").unwrap();
     let mut squashfs = Squashfs::from_reader(file);
 
-    let dirs = squashfs.dirs();
-    let inodes = squashfs.inodes();
+    let pos_and_inodes = squashfs.inodes();
+    let root_inode = squashfs.root_inode(&pos_and_inodes);
+    let inodes = squashfs.discard_pos(&pos_and_inodes);
+    let dir_blocks = squashfs.dir_blocks(&inodes);
     let fragments = squashfs.fragments();
 
-    let bytes = squashfs.extract_file("squashfs-deku", &dirs, &inodes, &fragments);
+    let (path, bytes) = squashfs.extract_file(
+        "squashfs-deku",
+        &dir_blocks,
+        &inodes,
+        &fragments,
+        &root_inode,
+    );
     let expected_bytes = fs::read("./lfs/test_02/squashfs-deku").unwrap();
+    assert_eq!(path.as_os_str(), "squashfs-deku");
     assert_eq!(bytes, expected_bytes);
 }
 
@@ -53,15 +80,80 @@ fn test_03() {
     let file = File::open("./lfs/test_03/out.squashfs").unwrap();
     let mut squashfs = Squashfs::from_reader(file);
 
-    let dirs = squashfs.dirs();
-    let inodes = squashfs.inodes();
+    let pos_and_inodes = squashfs.inodes();
+    let root_inode = squashfs.root_inode(&pos_and_inodes);
+    let inodes = squashfs.discard_pos(&pos_and_inodes);
+    let dir_blocks = squashfs.dir_blocks(&inodes);
     let fragments = squashfs.fragments();
 
-    let bytes = squashfs.extract_file("squashfs-deku", &dirs, &inodes, &fragments);
+    let (path, bytes) = squashfs.extract_file(
+        "squashfs-deku",
+        &dir_blocks,
+        &inodes,
+        &fragments,
+        &root_inode,
+    );
     let expected_bytes = fs::read("./lfs/test_03/squashfs-deku").unwrap();
+    assert_eq!(path.as_os_str(), "squashfs-deku");
     assert_eq!(bytes, expected_bytes);
 
-    let bytes = squashfs.extract_file("Cargo.toml", &dirs, &inodes, &fragments);
+    let (path, bytes) =
+        squashfs.extract_file("Cargo.toml", &dir_blocks, &inodes, &fragments, &root_inode);
     let expected_bytes = fs::read("./lfs/test_03/Cargo.toml").unwrap();
+    assert_eq!(path.as_os_str(), "Cargo.toml");
+    assert_eq!(bytes, expected_bytes);
+}
+
+#[test]
+fn test_04() {
+    let file = File::open("./lfs/test_04/out.squashfs").unwrap();
+    let mut squashfs = Squashfs::from_reader(file);
+
+    let pos_and_inodes = squashfs.inodes();
+    let root_inode = squashfs.root_inode(&pos_and_inodes);
+    let inodes = squashfs.discard_pos(&pos_and_inodes);
+    let dir_blocks = squashfs.dir_blocks(&inodes);
+    let fragments = squashfs.fragments();
+
+    let (path, bytes) = squashfs.extract_file("01", &dir_blocks, &inodes, &fragments, &root_inode);
+    let expected_bytes = fs::read("./lfs/test_04/testing/what/yikes/01").unwrap();
+    assert_eq!(path.as_os_str(), "what/yikes/01");
+    assert_eq!(bytes, expected_bytes);
+
+    let (path, bytes) = squashfs.extract_file("02", &dir_blocks, &inodes, &fragments, &root_inode);
+    let expected_bytes = fs::read("./lfs/test_04/testing/what/yikes/02").unwrap();
+    assert_eq!(path.as_os_str(), "what/yikes/02");
+    assert_eq!(bytes, expected_bytes);
+
+    let (path, bytes) = squashfs.extract_file("03", &dir_blocks, &inodes, &fragments, &root_inode);
+    let expected_bytes = fs::read("./lfs/test_04/testing/03").unwrap();
+    assert_eq!(path.as_os_str(), "03");
+    assert_eq!(bytes, expected_bytes);
+
+    let (path, bytes) = squashfs.extract_file("04", &dir_blocks, &inodes, &fragments, &root_inode);
+    let expected_bytes = fs::read("./lfs/test_04/testing/what/04").unwrap();
+    assert_eq!(path.as_os_str(), "what/04");
+    assert_eq!(bytes, expected_bytes);
+
+    let (path, bytes) = squashfs.extract_file("05", &dir_blocks, &inodes, &fragments, &root_inode);
+    let expected_bytes = fs::read("./lfs/test_04/testing/woah/05").unwrap();
+    assert_eq!(path.as_os_str(), "woah/05");
+    assert_eq!(bytes, expected_bytes);
+}
+
+#[test]
+fn test_05() {
+    let file = File::open("./lfs/test_05/out.squashfs").unwrap();
+    let mut squashfs = Squashfs::from_reader(file);
+
+    let pos_and_inodes = squashfs.inodes();
+    let root_inode = squashfs.root_inode(&pos_and_inodes);
+    let inodes = squashfs.discard_pos(&pos_and_inodes);
+    let dir_blocks = squashfs.dir_blocks(&inodes);
+    let fragments = squashfs.fragments();
+
+    let (path, bytes) = squashfs.extract_file("d", &dir_blocks, &inodes, &fragments, &root_inode);
+    let expected_bytes = fs::read("./lfs/test_05/a/b/c/d").unwrap();
+    assert_eq!(path.as_os_str(), "b/c/d");
     assert_eq!(bytes, expected_bytes);
 }


### PR DESCRIPTION
* Return filepath from extract_file
* Add tracing support for better debugging
* Add tests for new filepath
* Dir is now only deserialized during an inode lookup process. It is
  stored by the API user as metadata blocks