### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ name: ci
 
 jobs:
   # build, test all supported targets
-  build-test-stable:
+  build-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo build
-      - run: cargo test
+      - run: RUST_LOG=info cargo test
 
   # fmt and clippy on nightly builds
   fmt-clippy-nightly:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule: [cron: "40 1 * * *"]
+
+name: ci
+
+jobs:
+  # build, test all supported targets
+  build-test-stable:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+            # msrv
+          - 1.64.0
+
+    steps:
+      - run: sudo apt-get install -y squashfs-tools
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build
+      - run: cargo test
+
+  # fmt and clippy on nightly builds
+  fmt-clippy-nightly:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+
+      # fmt
+      - run: cargo fmt --all -- --check
+
+      # clippy
+      - run: cargo clippy -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-deku = { git = "https://github.com/sharksforarms/deku.git" }
+deku = "0.15.0"
 flate2 = "1.0.24"
 xz2 = "0.1.7"
 clap = { version = "4.0.12", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -16,10 +16,7 @@ let squashfs = Squashfs::from_reader(file).unwrap();
 let filesystem = squashfs.into_filesystem().unwrap();
 
 // write
-let id_table = Some(vec![Id(0x3e8)]);
-let bytes = filesystem
-    .to_bytes(squashfs.superblock.compressor, id_table)
-    .unwrap();
+let bytes = filesystem.to_bytes().unwrap();
 ```
 
 ### Modifying Firmware

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Squashfs-deku
+Squashfs-deku
+===============================
+
+[<img alt="github" src="https://img.shields.io/badge/github-wcampbell0x2a/squashfs-deku-8da0cb?style=for-the-badge&labelColor=555555&logo=github" height="20">](https://github.com/wcampbell0x2a/squashfs-deku)
+[<img alt="build status" src="https://img.shields.io/github/workflow/status/wcampbell0x2a/squashfs-deku/ci/master?style=for-the-badge" height="20">](https://github.com/wcampbell0x2a/squashfs-deku/actions?query=branch%3Amaster)
+
 Library and collection of binaries for the reading, creation, and modification 
 of [SquashFS](https://en.wikipedia.org/wiki/SquashFS) file systems.
 

--- a/src/bin/add.rs
+++ b/src/bin/add.rs
@@ -41,9 +41,7 @@ fn main() {
     filesystem.nodes.push(Node::File(new_file));
 
     // write new file
-    let bytes = filesystem
-        .to_bytes(squashfs.superblock.compressor, squashfs.id)
-        .unwrap();
+    let bytes = filesystem.to_bytes().unwrap();
     std::fs::write("added.squashfs", bytes).unwrap();
     println!("added file and wrote to added.squashfs");
 }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -146,7 +146,7 @@ impl Filesystem {
             }),
         };
 
-        let mut v = BitVec::<Msb0, u8>::new();
+        let mut v = BitVec::<u8, Msb0>::new();
         dir_inode.write(&mut v, (0, 0)).unwrap();
         let bytes = v.as_raw_slice().to_vec();
         inode_writer.write_all(&bytes).unwrap();
@@ -185,7 +185,7 @@ impl Filesystem {
         };
         *inode += 1;
 
-        let mut v = BitVec::<Msb0, u8>::new();
+        let mut v = BitVec::<u8, Msb0>::new();
         dir_inode.write(&mut v, (0, 0)).unwrap();
         let bytes = v.as_raw_slice().to_vec();
         let start = inode_writer.metadata_start;
@@ -230,7 +230,7 @@ impl Filesystem {
         };
         *inode += 1;
 
-        let mut v = BitVec::<Msb0, u8>::new();
+        let mut v = BitVec::<u8, Msb0>::new();
         file_inode.write(&mut v, (0, 0)).unwrap();
         let bytes = v.as_raw_slice().to_vec();
         let start = inode_writer.metadata_start;
@@ -271,7 +271,7 @@ impl Filesystem {
         };
         *inode += 1;
 
-        let mut v = BitVec::<Msb0, u8>::new();
+        let mut v = BitVec::<u8, Msb0>::new();
         sym_inode.write(&mut v, (0, 0)).unwrap();
         let bytes = v.as_raw_slice().to_vec();
         let start = inode_writer.metadata_start;

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -297,7 +297,7 @@ impl Filesystem {
         id_table: Option<Vec<Id>>,
     ) -> Result<Vec<u8>, SquashfsError> {
         let mut superblock = SuperBlock::new(compressor);
-        info!("{:#02x?}", self.nodes);
+        trace!("{:#02x?}", self.nodes);
         info!("Creating Tree");
         let tree = TreeNode::from(self);
         info!("Tree Created");

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -37,6 +37,7 @@ impl Filesystem {
     // This works my recursively creating Inodes and Dirs for each node in the tree. This also
     // keeps track of parent directories by calling this function on all nodes of a dir to get only
     // the nodes, but going into the child dirs in the case that it contains a child dir.
+    #[allow(clippy::too_many_arguments)]
     #[instrument(skip_all)]
     fn write_node(
         tree: &TreeNode,

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,3 +1,5 @@
+//! In-memory representation of SquashFS used for writing to image
+
 use core::fmt;
 use std::ffi::OsString;
 use std::io::{Cursor, Seek, Write};
@@ -341,6 +343,12 @@ impl Filesystem {
         info!("Writing Dirs");
         superblock.dir_table = c.position();
         c.write_all(&dir_writer.finalize())?;
+
+        // TODO(#24): Add fragment support
+        //
+        // This is written to the position of the dir_table to support older versions of unsquashfs
+        // that don't support the empty 0xffff_ffff_ffff_ffff
+        superblock.frag_table = c.position();
 
         info!("Writing Id Lookup Table");
         Self::write_id_table(&mut c, id_table, &mut superblock)?;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -100,7 +100,7 @@ impl SquashfsReader {
                     //trace!("{inode:02x?}");
                     trace!("{:02x?}", inode);
                     ret_vec.push(inode);
-                    ret_bytes = rest.as_raw_slice().to_vec();
+                    ret_bytes = rest.domain().region().unwrap().1.to_vec();
                 },
                 Err(e) => {
                     // TODO: this should return an error

--- a/src/squashfs.rs
+++ b/src/squashfs.rs
@@ -17,12 +17,12 @@ use crate::metadata;
 use crate::reader::{ReadSeek, SquashfsReader};
 
 /// NFS export support
-#[derive(Debug, Copy, Clone, DekuRead, DekuWrite)]
+#[derive(Debug, Copy, Clone, DekuRead, DekuWrite, PartialEq, Eq)]
 #[deku(endian = "little")]
 pub struct Export(pub u64);
 
 /// 32 bit user and group IDs
-#[derive(Debug, Copy, Clone, DekuRead, DekuWrite)]
+#[derive(Debug, Copy, Clone, DekuRead, DekuWrite, PartialEq, Eq)]
 #[deku(endian = "little")]
 pub struct Id(pub u32);
 
@@ -423,7 +423,13 @@ impl Squashfs {
             path: "/".into(),
         };
 
-        let filesystem = Filesystem { root_inode, nodes };
+        let filesystem = Filesystem {
+            compressor: self.superblock.compressor,
+            compression_options: self.compression_options,
+            id_table: self.id.clone(),
+            root_inode,
+            nodes,
+        };
         Ok(filesystem)
     }
 

--- a/src/squashfs.rs
+++ b/src/squashfs.rs
@@ -228,7 +228,7 @@ impl Squashfs {
                     );
                 }
                 // data -> compression options
-                let bv = BitVec::from_slice(&bytes).unwrap();
+                let bv = BitVec::from_slice(&bytes);
                 let (_, c) = CompressionOptions::read(
                     &bv,
                     (deku::ctx::Endian::Little, superblock.compressor),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -42,7 +42,6 @@ impl TreeNode {
 
     fn insert(&mut self, fullpath: &mut PathBuf, components: &[&OsStr], og_node: &Node) {
         if let Some((first, rest)) = components.split_first() {
-            println!("{first:?}, {rest:?}");
             fullpath.push(first);
 
             // no rest, we have the file

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -669,23 +669,3 @@ fn test_10() {
     const TEST_PATH: &str = "test-assets/test_10";
     factory_test(&asset_defs, FILE_NAME, TEST_PATH, 0x2c0080);
 }
-
-#[test]
-fn test_11() {
-    let file = File::open("out.squashfs").unwrap();
-    info!("{file:?}");
-    let squashfs = Squashfs::from_reader(file).unwrap();
-    info!("{:02x?}", squashfs.superblock);
-
-    let filesystem = squashfs.into_filesystem().unwrap();
-
-    // convert to bytes
-    let id_table = Some(vec![Id(0x1879a), Id(0x186a0)]);
-    let bytes = filesystem
-        .to_bytes(squashfs.superblock.compressor, id_table)
-        .unwrap();
-    fs::write("bytes.squashfs", &bytes).unwrap();
-
-    // assert that our library can atleast read the output, use unsquashfs to really assert this
-    let _new_squashfs = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
-}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -84,11 +84,7 @@ fn test_00() {
 
     // convert to bytes
     let filesystem = squashfs.into_filesystem().unwrap();
-    let id_table = Some(vec![Id(0x3e8)]);
-
-    let bytes = filesystem
-        .to_bytes(squashfs.superblock.compressor, id_table)
-        .unwrap();
+    let bytes = filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
@@ -143,10 +139,7 @@ fn test_01() {
     }
 
     // convert to bytes
-    let id_table = Some(vec![Id(0x3e8)]);
-    let bytes = filesystem
-        .to_bytes(squashfs.superblock.compressor, id_table)
-        .unwrap();
+    let bytes = filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
@@ -201,10 +194,7 @@ fn test_02() {
     }
 
     // convert to bytes
-    let id_table = Some(vec![Id(0x3e8)]);
-    let bytes = filesystem
-        .to_bytes(squashfs.superblock.compressor, id_table)
-        .unwrap();
+    let bytes = filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
@@ -269,10 +259,7 @@ fn test_03() {
     }
 
     // convert to bytes
-    let id_table = Some(vec![Id(0x3e8)]);
-    let bytes = filesystem
-        .to_bytes(squashfs.superblock.compressor, id_table)
-        .unwrap();
+    let bytes = filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
@@ -369,10 +356,7 @@ fn test_04() {
         }
     }
     // convert to bytes
-    let id_table = Some(vec![Id(0x3e8)]);
-    let bytes = filesystem
-        .to_bytes(squashfs.superblock.compressor, id_table)
-        .unwrap();
+    let bytes = filesystem.to_bytes().unwrap();
 
     fs::write(&new_path, &bytes).unwrap();
 
@@ -444,10 +428,7 @@ fn test_05() {
     }
 
     // convert to bytes
-    let id_table = Some(vec![Id(0x3e8)]);
-    let bytes = filesystem
-        .to_bytes(squashfs.superblock.compressor, id_table)
-        .unwrap();
+    let bytes = filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
@@ -495,10 +476,7 @@ fn test_06() {
     let filesystem = squashfs.into_filesystem().unwrap();
 
     // convert to bytes
-    let id_table = Some(vec![Id(0x3e8)]);
-    let bytes = filesystem
-        .to_bytes(squashfs.superblock.compressor, id_table)
-        .unwrap();
+    let bytes = filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
@@ -546,10 +524,7 @@ fn test_07() {
     let filesystem = squashfs.into_filesystem().unwrap();
 
     // convert to bytes
-    let id_table = Some(vec![Id(0x3e8)]);
-    let bytes = filesystem
-        .to_bytes(squashfs.superblock.compressor, id_table)
-        .unwrap();
+    let bytes = filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
@@ -597,10 +572,7 @@ fn test_08() {
     let filesystem = squashfs.into_filesystem().unwrap();
 
     // convert to bytes
-    let id_table = Some(vec![Id(0x3e8)]);
-    let bytes = filesystem
-        .to_bytes(squashfs.superblock.compressor, id_table)
-        .unwrap();
+    let bytes = filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
@@ -625,10 +597,7 @@ fn factory_test(assets_defs: &[TestAssetDef], filepath: &str, test_path: &str, o
 
     // convert to bytes
     let og_filesystem = squashfs.into_filesystem().unwrap();
-    let id_table = Some(vec![Id(0x3e8)]);
-    let bytes = og_filesystem
-        .to_bytes(squashfs.superblock.compressor, id_table)
-        .unwrap();
+    let bytes = og_filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this


### PR DESCRIPTION
* support version unsquashfs version 4.5 (2021/07/22) by not using 0xffff_ffff_ffff_ffff for empty fragment table location. This version is used by the `ubuntu-latest`
* Add CI
* Improve API