### PR TITLE
Rewrite into_filesystem to start at root_inode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "4.0.12", features = ["derive"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "fmt"] }
 thiserror = "1.0.37"
+twox-hash = "1.6.3"
 
 [dev-dependencies]
 env_logger = "0.9.1"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ of [SquashFS](https://en.wikipedia.org/wiki/SquashFS) file systems.
 
 | :warning: WARNING                                                                          |
 |:-------------------------------------------------------------------------------------------|
-| The API for this libary **isn't** complete. I will most likely break this for improvements |
+| The API for this library **isn't** complete. I will most likely break this for improvements |
 
 ## Library
 See `cargo doc`, but here are some examples
@@ -43,7 +43,6 @@ These are currently under development and are missing features, MR's welcome!
 Usage: unsquashfs [OPTIONS] <INPUT> <COMMAND>
 
 Commands:
-  extract-files  Extract single file from image
   extract-all    Extract all files(Symlink/Files/Dirs) from image
   help           Print this message or the help of the given subcommand(s)
 

--- a/src/bin/unsquashfs.rs
+++ b/src/bin/unsquashfs.rs
@@ -22,15 +22,15 @@ struct Args {
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
-    /// Extract single file from image
-    ExtractFiles {
-        /// Filepath to extract
-        #[arg(short, long)]
-        filepath: Vec<String>,
+    ///// Extract single file from image
+    //ExtractFiles {
+    //    /// Filepath to extract
+    //    #[arg(short, long)]
+    //    filepath: Vec<String>,
 
-        #[arg(short, long, default_value = "output")]
-        output: PathBuf,
-    },
+    //    #[arg(short, long, default_value = "output")]
+    //    output: PathBuf,
+    //},
     /// Extract all files(Symlink/Files/Dirs) from image
     ExtractAll {
         #[arg(short, long, default_value = "output")]
@@ -44,33 +44,10 @@ fn main() {
     let args = Args::parse();
 
     match args.cmd {
-        Command::ExtractFiles { filepath, output } => {
-            extract(&args.input, args.offset, filepath, &output)
-        },
+        //Command::ExtractFiles { filepath, output } => {
+        //    extract(&args.input, args.offset, filepath, &output)
+        //},
         Command::ExtractAll { output } => extract_all(&args.input, args.offset, &output),
-    }
-}
-
-fn extract(input: &Path, offset: u64, filepath: Vec<String>, output: &Path) {
-    let file = File::open(input).unwrap();
-    let squashfs = Squashfs::from_reader_with_offset(file, offset).unwrap();
-    tracing::info!("SuperBlock: {:#02x?}", squashfs.superblock);
-    tracing::debug!("Inodes: {:#02x?}", squashfs.inodes);
-    tracing::debug!("Dir Blocks: {:#02x?}", squashfs.dir_blocks);
-    tracing::debug!("Root inode: {:#02x?}", squashfs.root_inode);
-    tracing::debug!("Fragments {:#02x?}", squashfs.fragments);
-
-    for filepath in &filepath {
-        let (filepath, bytes) = squashfs.extract_file(filepath).unwrap();
-        let filepath = Path::new(output).join(filepath);
-        //println!("[-] {}", filepath.parent().unwrap().display());
-        let _ = std::fs::create_dir_all(filepath.parent().unwrap());
-        match std::fs::write(&filepath, bytes) {
-            Ok(_) => println!("[-] success, wrote to {}", filepath.display()),
-            Err(e) => {
-                println!("[!] failed to write: {} : {e}", filepath.display())
-            },
-        }
     }
 }
 

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -115,7 +115,7 @@ impl Filesystem {
             dir_writer.write_all(&bytes).unwrap();
         }
 
-        trace!("BEFORE: {:#02x?}", child);
+        //trace!("BEFORE: {:#02x?}", child);
         let offset = inode_writer.uncompressed_bytes.len() as u16;
         let start = inode_writer.metadata_start;
         let entry = Entry {
@@ -320,7 +320,7 @@ impl Filesystem {
 
         info!("Creating Inodes and Dirs");
         let mut inode = 1;
-        trace!("TREE: {:#02x?}", tree);
+        //trace!("TREE: {:#02x?}", tree);
         let (_, _, root_inode) = Self::write_node(
             &tree,
             &tree,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -85,7 +85,6 @@ impl From<&Filesystem> for TreeNode {
                     tree.insert(&mut PathBuf::new(), &comp, node);
                 },
                 Node::Path(path) => {
-                    tracing::trace!("PPPPP{:#x?}", path);
                     let path = path.path.as_path();
                     let comp = normalized_components(path);
                     tree.insert(&mut PathBuf::new(), &comp, node);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -76,23 +76,13 @@ fn test_00() {
         }))
     );
 
-    let (path, file_bytes) = squashfs.extract_file("squashfs-deku").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/squashfs-deku")).unwrap();
-    assert_eq!(path.as_os_str(), "squashfs-deku");
-    assert_eq!(file_bytes, expected_bytes);
-
     // convert to bytes
     let filesystem = squashfs.into_filesystem().unwrap();
     let bytes = filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
-    let new_squashfs = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
-
-    // assert that we can read from this new squashfs image
-    let (new_pathbuf, new_file_bytes) = new_squashfs.extract_file("squashfs-deku").unwrap();
-    assert_eq!(path, new_pathbuf);
-    assert_eq!(file_bytes, new_file_bytes);
+    let _ = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
 
     test_unsquashfs(&og_path, &new_path, None);
 }
@@ -123,31 +113,14 @@ fn test_01() {
     let squashfs = Squashfs::from_reader(file).unwrap();
     info!("{:02x?}", squashfs.superblock);
 
-    let (path, file_bytes) = squashfs.extract_file("squashfs-deku").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/squashfs-deku")).unwrap();
-    assert_eq!(path.as_os_str(), "squashfs-deku");
-    assert_eq!(file_bytes, expected_bytes);
-
     let filesystem = squashfs.into_filesystem().unwrap();
-    for u in &filesystem.nodes {
-        if let Node::File(SquashfsFile { path, bytes, .. }) = u {
-            let filepath = Path::new(TEST_PATH).join(path);
-            let expected_bytes = fs::read(filepath).unwrap();
-            assert_eq!(bytes, &*expected_bytes);
-        }
-    }
 
     // convert to bytes
     let bytes = filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
-    let new_squashfs = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
-
-    // assert that we can read from this new squashfs image
-    let (new_pathbuf, new_file_bytes) = new_squashfs.extract_file("squashfs-deku").unwrap();
-    assert_eq!(path, new_pathbuf);
-    assert_eq!(file_bytes, new_file_bytes);
+    let _ = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
 
     test_unsquashfs(&og_path, &new_path, None);
 }
@@ -178,31 +151,13 @@ fn test_02() {
     let squashfs = Squashfs::from_reader(file).unwrap();
     info!("{:02x?}", squashfs.superblock);
 
-    let (path, file_bytes) = squashfs.extract_file("squashfs-deku").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/squashfs-deku")).unwrap();
-    assert_eq!(path.as_os_str(), "squashfs-deku");
-    assert_eq!(file_bytes, expected_bytes);
-
     let filesystem = squashfs.into_filesystem().unwrap();
-    for u in &filesystem.nodes {
-        if let Node::File(SquashfsFile { path, bytes, .. }) = u {
-            let filepath = Path::new(TEST_PATH).join(path);
-            let expected_bytes = fs::read(filepath).unwrap();
-            assert_eq!(bytes, &*expected_bytes);
-        }
-    }
-
     // convert to bytes
     let bytes = filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
-    let new_squashfs = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
-
-    // assert that we can read from this new squashfs image
-    let (new_pathbuf, new_file_bytes) = new_squashfs.extract_file("squashfs-deku").unwrap();
-    assert_eq!(path, new_pathbuf);
-    assert_eq!(file_bytes, new_file_bytes);
+    let _ = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
 
     test_unsquashfs(&og_path, &new_path, None);
 }
@@ -238,40 +193,14 @@ fn test_03() {
     let squashfs = Squashfs::from_reader(file).unwrap();
     info!("{:02x?}", squashfs.superblock);
 
-    let (path_00, file_bytes_00) = squashfs.extract_file("squashfs-deku").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/squashfs-deku")).unwrap();
-    assert_eq!(path_00.as_os_str(), "squashfs-deku");
-    assert_eq!(file_bytes_00, expected_bytes);
-
-    let (path_01, file_bytes_01) = squashfs.extract_file("Cargo.toml").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/Cargo.toml")).unwrap();
-    assert_eq!(path_01.as_os_str(), "Cargo.toml");
-    assert_eq!(file_bytes_01, expected_bytes);
-
     let filesystem = squashfs.into_filesystem().unwrap();
-    for u in &filesystem.nodes {
-        if let Node::File(SquashfsFile { path, bytes, .. }) = u {
-            let filepath = Path::new(TEST_PATH).join(path);
-            let expected_bytes = fs::read(filepath).unwrap();
-            assert_eq!(bytes, &*expected_bytes);
-        }
-    }
 
     // convert to bytes
     let bytes = filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
-    let new_squashfs = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
-
-    // assert that we can read from this new squashfs image
-    let (new_pathbuf, new_file_bytes_00) = new_squashfs.extract_file("squashfs-deku").unwrap();
-    assert_eq!(path_00, new_pathbuf);
-    assert_eq!(file_bytes_00, new_file_bytes_00);
-
-    let (new_pathbuf, new_file_bytes_01) = new_squashfs.extract_file("Cargo.toml").unwrap();
-    assert_eq!(path_01, new_pathbuf);
-    assert_eq!(file_bytes_01, new_file_bytes_01);
+    let _ = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
 
     test_unsquashfs(&og_path, &new_path, None);
 }
@@ -321,31 +250,6 @@ fn test_04() {
     let squashfs = Squashfs::from_reader(file).unwrap();
     info!("{:02x?}", squashfs.superblock);
 
-    let (path_00, file_bytes_00) = squashfs.extract_file("01").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/01")).unwrap();
-    assert_eq!(path_00.as_os_str(), "what/yikes/01");
-    assert_eq!(file_bytes_00, expected_bytes);
-
-    let (path_01, file_bytes_01) = squashfs.extract_file("02").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/02")).unwrap();
-    assert_eq!(path_01.as_os_str(), "what/yikes/02");
-    assert_eq!(file_bytes_01, expected_bytes);
-
-    let (path_02, file_bytes_02) = squashfs.extract_file("03").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/03")).unwrap();
-    assert_eq!(path_02.as_os_str(), "03");
-    assert_eq!(file_bytes_02, expected_bytes);
-
-    let (path_03, file_bytes_03) = squashfs.extract_file("04").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/04")).unwrap();
-    assert_eq!(path_03.as_os_str(), "what/04");
-    assert_eq!(file_bytes_03, expected_bytes);
-
-    let (path_04, file_bytes_04) = squashfs.extract_file("05").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/05")).unwrap();
-    assert_eq!(path_04.as_os_str(), "woah/05");
-    assert_eq!(file_bytes_04, expected_bytes);
-
     let filesystem = squashfs.into_filesystem().unwrap();
     for u in &filesystem.nodes {
         if let Node::File(SquashfsFile { path, bytes, .. }) = u {
@@ -362,27 +266,6 @@ fn test_04() {
     // assert that our library can atleast read the output, use unsquashfs to really assert this
     let new_squashfs = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
     tracing::trace!("{:#02x?}", new_squashfs.inodes);
-
-    // assert that we can read from this new squashfs image
-    let (new_pathbuf, new_file_bytes_00) = new_squashfs.extract_file("01").unwrap();
-    assert_eq!(path_00, new_pathbuf);
-    assert_eq!(file_bytes_00, new_file_bytes_00);
-
-    let (new_pathbuf, new_file_bytes_01) = new_squashfs.extract_file("02").unwrap();
-    assert_eq!(path_01, new_pathbuf);
-    assert_eq!(file_bytes_01, new_file_bytes_01);
-
-    let (new_pathbuf, new_file_bytes_02) = new_squashfs.extract_file("03").unwrap();
-    assert_eq!(path_02, new_pathbuf);
-    assert_eq!(file_bytes_02, new_file_bytes_02);
-
-    let (new_pathbuf, new_file_bytes_03) = new_squashfs.extract_file("04").unwrap();
-    assert_eq!(path_03, new_pathbuf);
-    assert_eq!(file_bytes_03, new_file_bytes_03);
-
-    let (new_pathbuf, new_file_bytes_04) = new_squashfs.extract_file("05").unwrap();
-    assert_eq!(path_04, new_pathbuf);
-    assert_eq!(file_bytes_04, new_file_bytes_04);
 
     test_unsquashfs(&og_path, &new_path, None);
 }
@@ -412,11 +295,6 @@ fn test_05() {
     let squashfs = Squashfs::from_reader(file).unwrap();
     info!("{:02x?}", squashfs.superblock);
 
-    let (path_00, file_bytes_00) = squashfs.extract_file("d").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/d")).unwrap();
-    assert_eq!(path_00.as_os_str(), "b/c/d");
-    assert_eq!(file_bytes_00, expected_bytes);
-
     let filesystem = squashfs.into_filesystem().unwrap();
     for u in &filesystem.nodes {
         if let Node::File(SquashfsFile { path, bytes, .. }) = u {
@@ -431,12 +309,7 @@ fn test_05() {
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
-    let new_squashfs = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
-
-    // assert that we can read from this new squashfs image
-    let (new_pathbuf, new_file_bytes_00) = new_squashfs.extract_file("d").unwrap();
-    assert_eq!(path_00, new_pathbuf);
-    assert_eq!(file_bytes_00, new_file_bytes_00);
+    let _ = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
 
     test_unsquashfs(&og_path, &new_path, None);
 }
@@ -466,12 +339,6 @@ fn test_06() {
     info!("{file:?}");
     let squashfs = Squashfs::from_reader(file).unwrap();
     info!("{:02x?}", squashfs.superblock);
-
-    let (path_00, file_bytes_00) = squashfs.extract_file("squashfs-deku").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/squashfs-deku")).unwrap();
-    assert_eq!(path_00.as_os_str(), "squashfs-deku");
-    assert_eq!(file_bytes_00, expected_bytes);
-
     let filesystem = squashfs.into_filesystem().unwrap();
 
     // convert to bytes
@@ -479,12 +346,7 @@ fn test_06() {
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
-    let new_squashfs = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
-
-    // assert that we can read from this new squashfs image
-    let (new_pathbuf, new_file_bytes_00) = new_squashfs.extract_file("squashfs-deku").unwrap();
-    assert_eq!(path_00, new_pathbuf);
-    assert_eq!(file_bytes_00, new_file_bytes_00);
+    let _ = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
 
     test_unsquashfs(&og_path, &new_path, None);
 }
@@ -515,11 +377,6 @@ fn test_07() {
     let squashfs = Squashfs::from_reader(file).unwrap();
     info!("{:02x?}", squashfs.superblock);
 
-    let (path_00, file_bytes_00) = squashfs.extract_file("squashfs-deku").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/squashfs-deku")).unwrap();
-    assert_eq!(path_00.as_os_str(), "squashfs-deku");
-    assert_eq!(file_bytes_00, expected_bytes);
-
     let filesystem = squashfs.into_filesystem().unwrap();
 
     // convert to bytes
@@ -527,12 +384,7 @@ fn test_07() {
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
-    let new_squashfs = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
-
-    // assert that we can read from this new squashfs image
-    let (new_pathbuf, new_file_bytes_00) = new_squashfs.extract_file("squashfs-deku").unwrap();
-    assert_eq!(path_00, new_pathbuf);
-    assert_eq!(file_bytes_00, new_file_bytes_00);
+    let _ = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
 
     test_unsquashfs(&og_path, &new_path, None);
 }
@@ -563,11 +415,6 @@ fn test_08() {
     let squashfs = Squashfs::from_reader(file).unwrap();
     info!("{:02x?}", squashfs.superblock);
 
-    let (path_00, file_bytes_00) = squashfs.extract_file("squashfs-deku").unwrap();
-    let expected_bytes = fs::read(format!("{TEST_PATH}/squashfs-deku")).unwrap();
-    assert_eq!(path_00.as_os_str(), "squashfs-deku");
-    assert_eq!(file_bytes_00, expected_bytes);
-
     let filesystem = squashfs.into_filesystem().unwrap();
 
     // convert to bytes
@@ -575,12 +422,7 @@ fn test_08() {
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
-    let new_squashfs = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
-
-    // assert that we can read from this new squashfs image
-    let (new_pathbuf, new_file_bytes_00) = new_squashfs.extract_file("squashfs-deku").unwrap();
-    assert_eq!(path_00, new_pathbuf);
-    assert_eq!(file_bytes_00, new_file_bytes_00);
+    let _ = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
 
     test_unsquashfs(&og_path, &new_path, None);
 }
@@ -591,18 +433,23 @@ fn factory_test(assets_defs: &[TestAssetDef], filepath: &str, test_path: &str, o
     let og_path = format!("{test_path}/{filepath}");
     let new_path = format!("{test_path}/bytes.squashfs");
     let file = File::open(&og_path).unwrap();
-    info!("{file:?}");
+    info!("calling from_reader");
     let squashfs = Squashfs::from_reader_with_offset(file, offset).unwrap();
 
     // convert to bytes
+    info!("calling into_filesystem");
     let og_filesystem = squashfs.into_filesystem().unwrap();
+    info!("calling to_bytes");
     let bytes = og_filesystem.to_bytes().unwrap();
     fs::write(&new_path, &bytes).unwrap();
 
     // assert that our library can atleast read the output, use unsquashfs to really assert this
+    info!("calling from_reader");
     let new_squashfs = Squashfs::from_reader(std::io::Cursor::new(bytes)).unwrap();
+    info!("calling into_filesystem");
     let _new_filesystem = new_squashfs.into_filesystem().unwrap();
 
+    info!("starting unsquashfs test");
     test_unsquashfs(&og_path, &new_path, Some(offset));
 }
 


### PR DESCRIPTION
* Instead of iterating through the inodes, use a HashMap of all inode numbers and start at the inode recursively calling the directory reading function